### PR TITLE
Enable i18n

### DIFF
--- a/languages/reading-time-wp.pot
+++ b/languages/reading-time-wp.pot
@@ -3,133 +3,133 @@ msgid ""
 msgstr ""
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 "Project-Id-Version: Reading Time WP\n"
-"POT-Creation-Date: 2018-08-02 23:48-0500\n"
+"POT-Creation-Date: 2018-12-05 07:59+0300\n"
 "PO-Revision-Date: 2018-08-02 23:48-0500\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.1.1\n"
+"X-Generator: Poedit 2.2\n"
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-Flags-xgettext: --add-comments=translators:\n"
 "X-Poedit-WPHeader: rt-reading-time.php\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Poedit-KeywordsList: __;_e;_n:1,2;_x:1,2c;_ex:1,2c;_nx:4c,1,2;esc_attr__;"
-"esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c;_n_noop:1,2;"
-"_nx_noop:3c,1,2;__ngettext_noop:1,2\n"
+"esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c;"
+"_n_noop:1,2;_nx_noop:3c,1,2;__ngettext_noop:1,2\n"
 "X-Poedit-SearchPath-0: .\n"
 "X-Poedit-SearchPathExcluded-0: *.js\n"
 
-#: rt-reading-time-admin.php:50
+#: rt-reading-time-admin.php:66
 msgid "Options saved."
 msgstr ""
 
-#: rt-reading-time-admin.php:74 rt-reading-time.php:151
+#: rt-reading-time-admin.php:100 rt-reading-time.php:233
 msgid "Reading Time WP Settings"
 msgstr ""
 
-#: rt-reading-time-admin.php:78
+#: rt-reading-time-admin.php:104
 msgid "Reading Time Settings"
 msgstr ""
 
-#: rt-reading-time-admin.php:80
+#: rt-reading-time-admin.php:106
 msgid "Reading time label: "
 msgstr ""
 
-#: rt-reading-time-admin.php:80
+#: rt-reading-time-admin.php:106
 msgid " This value appears before the reading time. Leave blank for none."
 msgstr ""
 
-#: rt-reading-time-admin.php:82
+#: rt-reading-time-admin.php:108
 msgid "Reading time postfix: "
 msgstr ""
 
-#: rt-reading-time-admin.php:82
+#: rt-reading-time-admin.php:108
 msgid " This value appears after the reading time. Leave blank for none."
 msgstr ""
 
-#: rt-reading-time-admin.php:83
+#: rt-reading-time-admin.php:109
 msgid "Reading time postfix singular: "
 msgstr ""
 
-#: rt-reading-time-admin.php:83
+#: rt-reading-time-admin.php:109
 msgid ""
 " This value appears after the reading time, when lecture time is 1 minute."
 msgstr ""
 
-#: rt-reading-time-admin.php:85
+#: rt-reading-time-admin.php:111
 msgid "Words per minute: "
 msgstr ""
 
-#: rt-reading-time-admin.php:85
+#: rt-reading-time-admin.php:111
 msgid " (defaults to 300, the average reading speed for adults)"
 msgstr ""
 
-#: rt-reading-time-admin.php:87
+#: rt-reading-time-admin.php:113
 msgid "Insert Reading Time before content: "
 msgstr ""
 
-#: rt-reading-time-admin.php:88
+#: rt-reading-time-admin.php:114
 msgid "Insert Reading Time before excerpt: "
 msgstr ""
 
-#: rt-reading-time-admin.php:89
+#: rt-reading-time-admin.php:115
 msgid "Exclude images from the reading time: "
 msgstr ""
 
-#: rt-reading-time-admin.php:90
+#: rt-reading-time-admin.php:116
 msgid "Include shortcodes in the reading time: "
 msgstr ""
 
-#: rt-reading-time-admin.php:91
+#: rt-reading-time-admin.php:118
 msgid "Select Post Types to Display Reading Time On"
 msgstr ""
 
-#: rt-reading-time-admin.php:102
+#: rt-reading-time-admin.php:123
 msgid "Display on "
 msgstr ""
 
-#: rt-reading-time-admin.php:107
+#: rt-reading-time-admin.php:128
 msgid "Update Options"
 msgstr ""
 
-#: rt-reading-time-admin.php:112
+#: rt-reading-time-admin.php:133
 msgid ""
 "Shortcode: <code>[rt_reading_time label=\"Reading Time:\" postfix=\"minutes"
 "\" postfix_singular=\"minute\"]</code>"
 msgstr ""
 
-#: rt-reading-time-admin.php:113
+#: rt-reading-time-admin.php:134
 msgid ""
 "Or simply use <code>[rt_reading_time]</code> to return the number with no "
 "labels."
 msgstr ""
 
-#: rt-reading-time-admin.php:114
+#: rt-reading-time-admin.php:135
 msgid ""
 "Want to insert the reading time into your theme? Use "
 "<code>do_shortcode('[rt_reading_time]')</code>."
 msgstr ""
 
-#: rt-reading-time.php:37
+#: rt-reading-time.php:66
 msgid "Reading Time: "
 msgstr ""
 
-#: rt-reading-time.php:38
+#: rt-reading-time.php:67
 msgid "minutes"
 msgstr ""
 
-#: rt-reading-time.php:39
+#: rt-reading-time.php:68
 msgid "minute"
 msgstr ""
 
-#: rt-reading-time.php:88
+#: rt-reading-time.php:144
 msgid "< 1"
 msgstr ""
 
 #. Plugin Name of the plugin/theme
-#: rt-reading-time.php:151
+#: rt-reading-time.php:234
 msgid "Reading Time WP"
 msgstr ""
 

--- a/languages/reading-time-wp.pot
+++ b/languages/reading-time-wp.pot
@@ -78,6 +78,10 @@ msgstr ""
 msgid "Exclude images from the reading time: "
 msgstr ""
 
+#: rt-reading-time-admin.php:90
+msgid "Include shortcodes in the reading time: "
+msgstr ""
+
 #: rt-reading-time-admin.php:91
 msgid "Select Post Types to Display Reading Time On"
 msgstr ""
@@ -130,7 +134,7 @@ msgid "Reading Time WP"
 msgstr ""
 
 #. Plugin URI of the plugin/theme
-msgid "http://jasonyingling.me/reading-time-wp/"
+msgid "https://jasonyingling.me/reading-time-wp/"
 msgstr ""
 
 #. Description of the plugin/theme
@@ -142,5 +146,5 @@ msgid "Jason Yingling"
 msgstr ""
 
 #. Author URI of the plugin/theme
-msgid "http://jasonyingling.me"
+msgid "https://jasonyingling.me"
 msgstr ""

--- a/rt-reading-time.php
+++ b/rt-reading-time.php
@@ -60,6 +60,8 @@ class Reading_Time_WP {
 	 * @since 1.0.0
 	 */
 	public function __construct() {
+		load_plugin_textdomain( 'reading-time-wp', false, basename( dirname( __FILE__ ) ) . '/languages/' );
+
 		$default_settings = array(
 			'label'              => __( 'Reading Time: ', 'reading-time-wp' ),
 			'postfix'            => __( 'minutes', 'reading-time-wp' ),


### PR DESCRIPTION
Loads the previously defined text domain
`https://wordpress.slack.com/archives/C0E7F4RND/p1541691267091300`

Updates the POT file:
- Missing string ("Include shortcodes in the reading time: ")
- Author URI https
- Update line numbers to match source