### PR TITLE
Add post_id optional attribute to shortcode 

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -63,6 +63,11 @@ Drop the code from this Gist in your functions.php https://gist.github.com/yingl
 
 Just hook into the `rtwp_filter_wordcount` filter and increment the word count the reading time is based on.
 
+= How do I specify a different post ID in the shortcode, e.g. to show each post's reading time on a page that lists many posts? =
+
+Use the optional page_id attribute on the shortcode. e.g. [rt_reading_time label="Reading Time:" postfix="minutes" postfix_singular="minute" post_id="123"]
+
+
 == Screenshots ==
 
 1. An example of an estimated reading time entered before "the_content".
@@ -85,7 +90,7 @@ Just hook into the `rtwp_filter_wordcount` filter and increment the word count t
 = 2.0.1 =
 * Fixing error with Reading Time shortcode when using postfix_singular attribute
 
-= 2.0.0 = 
+= 2.0.0 =
 * Updating plugin to better meet WordPress Coding Standards. This includes renaming variables throughout the plugin.
 * Note: If you've hooked into Reading Time WP's class, variables, or functions this update could cause issues.
 * Fixing HTML output when using shortcode to match auto inserted reading times

--- a/rt-reading-time-admin.php
+++ b/rt-reading-time-admin.php
@@ -139,5 +139,6 @@ if ( isset( $_POST['rt_reading_time_hidden'] ) && 'Y' == $_POST['rt_reading_time
 		<p><?php echo wp_kses_post( __( 'Shortcode: <code>[rt_reading_time label="Reading Time:" postfix="minutes" postfix_singular="minute"]</code>', 'reading-time-wp' ) ); ?></p>
 		<p><?php echo wp_kses_post( __( 'Or simply use <code>[rt_reading_time]</code> to return the number with no labels.', 'reading-time-wp' ) ); ?></p>
 		<p><?php echo wp_kses_post( __( 'Want to insert the reading time into your theme? Use <code>do_shortcode(\'[rt_reading_time]\')</code>.', 'reading-time-wp' ) ); ?></p>
+		<p><?php echo wp_kses_post( __( 'The shortcode shows the reading time for the current page/post by default. To show the reading time for another one, use the optional "post_id" attribute. For example - to show the reading time for post ID 123: <code>[rt_reading_time post_id="123"]</code>.', 'reading-time-wp' ) ); ?></p>
 	</div>
 </div>

--- a/rt-reading-time.php
+++ b/rt-reading-time.php
@@ -191,6 +191,7 @@ class Reading_Time_WP {
 				'label'            => '',
 				'postfix'          => '',
 				'postfix_singular' => '',
+				'post_id' => '',
 			),
 			$atts,
 			'rt_reading_time'
@@ -198,7 +199,8 @@ class Reading_Time_WP {
 
 		$rt_reading_time_options = get_option( 'rt_reading_time_options' );
 
-		$rt_post = get_the_ID();
+		// If post_id attribute was specified that exists, then use that to calculate read time, else use the current post ID
+		$rt_post = $atts['post_id'] && ( get_post_status($atts['post_id']) ) ? $atts['post_id'] : get_the_ID();
 
 		$this->rt_calculate_reading_time( $rt_post, $rt_reading_time_options );
 


### PR DESCRIPTION
This allows a different post ID to be specified than the current page, for example, on post list pages to show each post's reading time.