### PR TITLE
make it work with elementor pages

### DIFF
--- a/rt-reading-time.php
+++ b/rt-reading-time.php
@@ -135,7 +135,7 @@ class Reading_Time_WP {
 	 */
 	public function rt_calculate_reading_time( $rt_post_id, $rt_options ) {
 
-		$rt_content       = get_post_field( 'post_content', $rt_post_id );
+		$rt_content 	  = apply_filters( 'the_content', $content );
 		$number_of_images = substr_count( strtolower( $rt_content ), '<img ' );
 
 		if ( ! isset( $rt_options['include_shortcodes'] ) ) {


### PR DESCRIPTION
`post_content` isn't always populated at this point. Elementor for instance uses the `the_content` hook, I think also normal posts as well. That's why this way it would be more compatible. Would be cool if this could be incorporated within the next release, so we don't have to monkey patch it every time :) 

thanks