### PR TITLE
Refactor plugin object initialization to the WP init function rather than during parsing.

### DIFF
--- a/rt-reading-time-admin.php
+++ b/rt-reading-time-admin.php
@@ -7,6 +7,11 @@
  * @package Reading_Time_WP
  */
 
+// If this file is called directly, abort.
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
 global $reading_time_wp;
 
 $rt_reading_time_options = get_option( 'rt_reading_time_options' );

--- a/rt-reading-time-admin.php
+++ b/rt-reading-time-admin.php
@@ -2,6 +2,8 @@
 /**
  * Functions for building out the Reading Time settings page.
  *
+ * Loaded by add_options_page action wrapper in rt-reading-time.php
+ *
  * @package Reading_Time_WP
  */
 

--- a/rt-reading-time.php
+++ b/rt-reading-time.php
@@ -378,4 +378,14 @@ class Reading_Time_WP {
 
 }
 
-$reading_time_wp = new Reading_Time_WP();
+/**
+ * Initialize Reading Time WP.
+ *
+ * @global \Reading_Time_WP $reading_time_wp Initialized plugin object.
+ * @return void
+ */
+function rtwp_init() {
+	global $reading_time_wp;
+	$reading_time_wp = new Reading_Time_WP();
+}
+add_action( 'init', 'rtwp_init', 50 );


### PR DESCRIPTION
Resolves #15

Tested with no detectible impact on a new install.

In `rt-reading-time-admin.php` also commented to describe behavior that confused me initially and prevented direct access.