### PR TITLE
Revert "Add filter to manage post types wanted to work"

### DIFF
--- a/rt-reading-time.php
+++ b/rt-reading-time.php
@@ -92,7 +92,6 @@ class Reading_Time_WP {
 		$rtwp_post_type_args = apply_filters( 'rtwp_post_type_args', $rtwp_post_type_args );
 
 		$rtwp_post_types = get_post_types( $rtwp_post_type_args );
-		$rtwp_post_types = apply_filters( 'rtwp_post_types', $rtwp_post_types );
 
 		foreach ( $rtwp_post_types as $rtwp_post_type ) {
 			if ( 'attachment' === $rtwp_post_type ) {
@@ -104,7 +103,7 @@ class Reading_Time_WP {
 		$rt_reading_time_options = get_option( 'rt_reading_time_options' );
 
 		add_shortcode( 'rt_reading_time', array( $this, 'rt_reading_time' ) );
-		update_option( 'rt_reading_time_options', $default_settings );
+		add_option( 'rt_reading_time_options', $default_settings );
 		add_action( 'admin_menu', array( $this, 'rt_reading_time_admin_actions' ) );
 
 		$rt_before_content = isset($rt_reading_time_options['before_content'] ) ? $this->rt_convert_boolean( $rt_reading_time_options['before_content'] ) : false;


### PR DESCRIPTION
Reverts jasonyingling/reading-time-wp#25

Reverting since update_option actually will update all options to the defaults in this case.

Probably need to create a separate area for managing post types outside of the default settings that could be hooked into.